### PR TITLE
그룹 노티피케이션 목록 조회 시 그룹 ID 부분에 회원 ID가 기입된 부분 수정

### DIFF
--- a/common/src/main/kotlin/kr/respectme/common/response/ApiResult.kt
+++ b/common/src/main/kotlin/kr/respectme/common/response/ApiResult.kt
@@ -1,7 +1,6 @@
 package kr.respectme.common.response
 
 import org.slf4j.MDC
-import org.springframework.http.HttpStatus
 
 class ApiResult<T>(
     var traceId: String? = MDC.get("traceId"),

--- a/group-api/Dockerfile
+++ b/group-api/Dockerfile
@@ -1,3 +1,4 @@
 FROM openjdk:17.0.1-jdk-slim
-COPY build/libs/kr.respectme.group-api.test-latest.jar /app.jar
-CMD ["java", "-jar", "/app.jar"]
+COPY build/libs/kr.respectme.group-api-latest.jar /app.jar
+ENV SPRING_PROFILES_ACTIVE=test
+CMD ["java", "-jar", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "/app.jar"]

--- a/group-api/build.gradle.kts
+++ b/group-api/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     id("com.bmuschko.docker-remote-api") version "9.3.1"
 }
 
-version = "0.1.0"
+version = "0.1.1"
 
 repositories {
     mavenCentral()
@@ -77,7 +77,7 @@ kapt {
 }
 
 tasks.register<DockerBuildImage>("buildTestImage") {
-    dependsOn("bootTestJar")
+    dependsOn("bootJar")
     inputDir.set(file(".")) // Dockerfile이 위치한 경로 (프로젝트 root 경로)
     images.add("elensar92/respect-me-group-api:${version}-test")
     group = "docker"
@@ -88,26 +88,16 @@ tasks.register<DockerPushImage>("pushTestImage") {
     images.add("elensar92/respect-me-group-api:${version}-test")
     group = "docker"
 }
+tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar> {
+    archiveBaseName.set("${rootProject.group}.group-api")
+    archiveVersion.set("latest")
+}
 
-//tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootTestJar> {
-//    archiveBaseName.set("${rootProject.group}.group-api")
-//    archiveVersion.set("latest")
-//}
+
 
 tasks {
-
     bootRun {
         jvmArgs = listOf("-Dspring.profiles.active=local")
-    }
-
-    register<BootJar>("bootTestJar") {
-        archiveBaseName.set("${rootProject.group}.group-api.test-")
-        archiveVersion.set("latest")
-    }
-
-    register<BootJar>("bootProdJar") {
-        archiveBaseName.set("${rootProject.group}.group-api.prod-")
-        archiveVersion.set("latest")
     }
 }
 

--- a/group-api/src/main/kotlin/kr/respectme/group/adapter/out/persistence/JpaQueryGroupAdapter.kt
+++ b/group-api/src/main/kotlin/kr/respectme/group/adapter/out/persistence/JpaQueryGroupAdapter.kt
@@ -201,7 +201,7 @@ class JpaQueryGroupAdapter(
             Projections.constructor(
                 NotificationDto::class.java,
                 notification.id,
-                notification.memberId,
+                notification.groupId,
                 notification.content,
                 notification.type,
                 notification.status,


### PR DESCRIPTION
[변경 사항]

JpaQueryGroupAdapter의 메서드 retrieveGroupNotifications 메서드의 
Projection 생성자 매개변수 중 groupId 필드에 조회된 엔티티의 memberId 가 기입된 부분을
groupId로 수정