### PR TITLE
Auth api/feature unit test

### DIFF
--- a/auth-api/build.gradle.kts
+++ b/auth-api/build.gradle.kts
@@ -55,11 +55,13 @@ dependencies {
     // Logstash
     implementation("net.logstash.logback:logstash-logback-encoder:7.4")
 
+    testImplementation("io.mockk:mockk:1.13.4")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.1")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.1")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("io.kotest:kotest-runner-junit5:4.4.3")
-    testImplementation("io.kotest:kotest-assertions-core:4.4.3")
-    testImplementation("io.kotest:kotest-extensions-spring:4.4.3")
-    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 kapt {

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/AuthService.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/AuthService.kt
@@ -8,7 +8,7 @@ import kr.respectme.auth.application.dto.JwtAccessTokenVerifierRequiredInfo
 import kr.respectme.auth.application.dto.TokenValidationResult
 import kr.respectme.auth.application.useCase.AuthUseCase
 import kr.respectme.auth.common.AuthenticationErrorCode
-import kr.respectme.auth.common.jwt.JwtService
+import kr.respectme.auth.application.jwt.JwtService
 import kr.respectme.auth.configs.JwtConfigs
 import kr.respectme.auth.domain.MemberAuthInfoRepository
 import kr.respectme.auth.infrastructures.dto.LoginRequest

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/DefaultOidcAuthService.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/DefaultOidcAuthService.kt
@@ -3,11 +3,11 @@ package kr.respectme.auth.application
 import kr.respectme.auth.application.dto.AuthenticationResult
 import kr.respectme.auth.application.dto.OidcMemberLoginCommand
 import kr.respectme.auth.application.useCase.AuthUseCase
-import kr.respectme.auth.common.oidc.idToken.CommonOidcIdTokenPayload
+import kr.respectme.auth.application.oidc.idToken.CommonOidcIdTokenPayload
 import kr.respectme.auth.application.useCase.OidcAuthUseCase
 import kr.respectme.auth.common.AuthenticationErrorCode
-import kr.respectme.auth.common.jwt.JwtService
-import kr.respectme.auth.common.oidc.IdTokenVerifier
+import kr.respectme.auth.application.jwt.JwtService
+import kr.respectme.auth.application.oidc.IdTokenVerifier
 import kr.respectme.auth.domain.*
 import kr.respectme.auth.infrastructures.dto.CreateMemberRequest
 import kr.respectme.auth.infrastructures.dto.Member

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/DefaultOidcAuthService.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/DefaultOidcAuthService.kt
@@ -53,9 +53,9 @@ class DefaultOidcAuthService(
                 )
             ))
         }
+
         var memberInfo = memberLoadPort.loadMemberById(memberAuthInfo.memberId?.id!!).data
             ?: throw UnauthorizedException(AuthenticationErrorCode.FAILED_TO_SIGN_IN)
-
         val refreshToken = jwtService.createRefreshToken(memberInfo.id)
         val accessToken = jwtService.createAccessToken(memberInfo)
 

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/dto/OidcMemberLoginCommand.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/dto/OidcMemberLoginCommand.kt
@@ -5,7 +5,7 @@ import kr.respectme.auth.domain.OidcPlatform
 data class OidcMemberLoginCommand(
     val platform: OidcPlatform,
     val idToken: String,
-    val nickname: String?
+    val nickname: String?=null
 ) {
 
 }

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/jwt/JwtService.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/jwt/JwtService.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.jwt
+package kr.respectme.auth.application.jwt
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/AbstractJwksProvider.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/AbstractJwksProvider.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.oidc
+package kr.respectme.auth.application.oidc
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import kr.respectme.auth.common.AuthenticationErrorCode

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/AppleJwksProvider.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/AppleJwksProvider.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.oidc
+package kr.respectme.auth.application.oidc
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/GoogleJwksProvider.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/GoogleJwksProvider.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.oidc
+package kr.respectme.auth.application.oidc
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Qualifier

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/IdTokenVerifier.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/IdTokenVerifier.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.oidc
+package kr.respectme.auth.application.oidc
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
@@ -6,9 +6,9 @@ import com.auth0.jwt.exceptions.JWTVerificationException
 import com.auth0.jwt.interfaces.DecodedJWT
 import kr.respectme.auth.common.AuthenticationErrorCode
 import kr.respectme.auth.common.AuthenticationErrorCode.OIDC_ID_TOKEN_VERIFICATION_FAILED
-import kr.respectme.auth.common.oidc.idToken.AppleOidcIdTokenPayload
-import kr.respectme.auth.common.oidc.idToken.CommonOidcIdTokenPayload
-import kr.respectme.auth.common.oidc.idToken.GoogleOidcIdTokenPayload
+import kr.respectme.auth.application.oidc.idToken.AppleOidcIdTokenPayload
+import kr.respectme.auth.application.oidc.idToken.CommonOidcIdTokenPayload
+import kr.respectme.auth.application.oidc.idToken.GoogleOidcIdTokenPayload
 import kr.respectme.common.error.BadRequestException
 import kr.respectme.common.error.UnauthorizedException
 import org.springframework.beans.factory.annotation.Qualifier

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/IdTokenVerifier.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/IdTokenVerifier.kt
@@ -11,6 +11,7 @@ import kr.respectme.auth.application.oidc.idToken.CommonOidcIdTokenPayload
 import kr.respectme.auth.application.oidc.idToken.GoogleOidcIdTokenPayload
 import kr.respectme.common.error.BadRequestException
 import kr.respectme.common.error.UnauthorizedException
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import java.security.interfaces.RSAPublicKey
@@ -24,10 +25,14 @@ class IdTokenVerifier(
 ) {
 
     private val GOOGLE_ISSUER_STRING = "https://accounts.google.com"
+
     private val APPLE_ISSUER_STRING = "https://appleid.apple.com"
+
+    private val logger = LoggerFactory.getLogger(javaClass)
 
     fun verifyToken(idToken: String): CommonOidcIdTokenPayload {
         val decodedJWT = JWT.decode(idToken)
+        logger.debug("Decoded JWT: $decodedJWT")
         val pubKey = getPublicKey(decodedJWT)
         val algorithm = getAlgorithm(decodedJWT, pubKey)
         val verifier = JWT.require(algorithm)
@@ -55,7 +60,10 @@ class IdTokenVerifier(
         return when(decodedJWT.issuer) {
             GOOGLE_ISSUER_STRING -> googleJwksProvider.getPublicKey(kid)
             APPLE_ISSUER_STRING -> appleJwksProvider.getPublicKey(kid)
-            else -> throw BadRequestException(AuthenticationErrorCode.NOT_SUPPORTED_OIDC_PROVIDER)
+            else -> {
+                println("Not supported OIDC provider")
+                throw BadRequestException(AuthenticationErrorCode.NOT_SUPPORTED_OIDC_PROVIDER)
+            }
         }
     }
 

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/JWKKey.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/JWKKey.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.oidc
+package kr.respectme.auth.application.oidc
 
 data class JWKKey(
     val kty: String,

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/JwksProvider.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/JwksProvider.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.oidc
+package kr.respectme.auth.application.oidc
 
 import java.security.interfaces.RSAPublicKey
 

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/AppleOidcIdTokenPayload.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/AppleOidcIdTokenPayload.kt
@@ -5,7 +5,7 @@ import com.auth0.jwt.interfaces.DecodedJWT
 data class AppleOidcIdTokenPayload(
     val iss: String,
     val sub: String,
-    val aud: String,
+    val aud: List<String>,
     val iat: Long,
     val exp: Long,
     val email: String,
@@ -20,7 +20,7 @@ data class AppleOidcIdTokenPayload(
             return AppleOidcIdTokenPayload(
                 iss = decodedJWT.issuer,
                 sub = decodedJWT.subject,
-                aud = decodedJWT.audience[0],
+                aud = decodedJWT.audience,
                 iat = decodedJWT.issuedAt.time / 1000,
                 exp = decodedJWT.expiresAt.time / 1000,
                 email = decodedJWT.getClaim("email").asString(),

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/AppleOidcIdTokenPayload.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/AppleOidcIdTokenPayload.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.oidc.idToken
+package kr.respectme.auth.application.oidc.idToken
 
 import com.auth0.jwt.interfaces.DecodedJWT
 

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/CommonOidcIdTokenPayload.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/CommonOidcIdTokenPayload.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.oidc.idToken
+package kr.respectme.auth.application.oidc.idToken
 
 
 class CommonOidcIdTokenPayload(

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/CommonOidcIdTokenPayload.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/CommonOidcIdTokenPayload.kt
@@ -4,7 +4,7 @@ package kr.respectme.auth.application.oidc.idToken
 class CommonOidcIdTokenPayload(
     val iss: String,
     val sub: String,
-    val aud: String,
+    val aud: List<String>,
     val iat: Long,
     val exp: Long,
     val email: String,

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/GoogleOidcIdTokenPayload.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/GoogleOidcIdTokenPayload.kt
@@ -5,7 +5,7 @@ import com.auth0.jwt.interfaces.DecodedJWT
 class GoogleOidcIdTokenPayload(
     val iss: String,
     val sub: String,
-    val aud: String,
+    val aud: List<String>,
     val iat: Long,
     val exp: Long,
     val email: String,
@@ -23,7 +23,7 @@ class GoogleOidcIdTokenPayload(
             return GoogleOidcIdTokenPayload(
                 iss = decodedJWT.issuer,
                 sub = decodedJWT.subject,
-                aud = decodedJWT.audience[0],
+                aud = decodedJWT.audience,
                 iat = decodedJWT.issuedAt.time / 1000,
                 exp = decodedJWT.expiresAt.time / 1000,
                 email = decodedJWT.claims["email"]?.asString() ?: "",

--- a/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/GoogleOidcIdTokenPayload.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/application/oidc/idToken/GoogleOidcIdTokenPayload.kt
@@ -1,4 +1,4 @@
-package kr.respectme.auth.common.oidc.idToken
+package kr.respectme.auth.application.oidc.idToken
 
 import com.auth0.jwt.interfaces.DecodedJWT
 

--- a/auth-api/src/main/kotlin/kr/respectme/auth/configs/SecurityConfig.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/configs/SecurityConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.stereotype.Component
 import org.springframework.web.cors.CorsConfiguration
@@ -26,6 +27,11 @@ class SecurityConfig(
     private val allowedOrigins = allowedOriginsString.split(",")
 
     private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Bean
+    fun passwordEncoder(): BCryptPasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
 
     @Bean
     fun corsConfig(): CorsConfiguration {

--- a/auth-api/src/main/kotlin/kr/respectme/auth/domain/MemberAuthInfo.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/domain/MemberAuthInfo.kt
@@ -14,11 +14,8 @@ class MemberAuthInfo(
     @Id
     @Embedded
     val memberId: MemberId? = null,
-    @Column
-    val email: String = "",
-    @Column
-    val password: String? = null,
-
+    email: String = "",
+    password: String? = null,
     @AttributeOverrides(
         AttributeOverride(name = "platform", column = Column(name = "oidc_auth_platform")),
         AttributeOverride(name = "userIdentifier", column = Column(name = "oidc_auth_user_identifier", nullable = true))
@@ -27,8 +24,16 @@ class MemberAuthInfo(
     lastLoginAt: Instant? = null
 ){
     @Column
+    var email: String = email
+        protected set
+
+    @Column
+    var password: String? = password
+        protected set
+
+    @Column
     var lastLoginAt: Instant? = lastLoginAt
-    protected set
+        protected set
 
     fun login() {
         lastLoginAt = Instant.now()

--- a/auth-api/src/main/kotlin/kr/respectme/auth/infrastructures/dto/CreateMemberRequest.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/infrastructures/dto/CreateMemberRequest.kt
@@ -2,7 +2,7 @@ package kr.respectme.auth.infrastructures.dto
 
 data class CreateMemberRequest(
     val email: String,
-    val nickname: String,
+    val nickname: String? = null,
     val profileImageUrl: String?,
 ) {
 

--- a/auth-api/src/main/kotlin/kr/respectme/auth/interfaces/adapter/OidcAuthServiceAdapter.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/interfaces/adapter/OidcAuthServiceAdapter.kt
@@ -3,6 +3,7 @@ package kr.respectme.auth.interfaces.adapter
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import jakarta.validation.Valid
 import kr.respectme.auth.application.dto.OidcMemberLoginCommand
 import kr.respectme.auth.application.useCase.OidcAuthUseCase
 import kr.respectme.auth.domain.OidcPlatform
@@ -12,6 +13,7 @@ import kr.respectme.auth.interfaces.port.OidcAuthPort
 import kr.respectme.common.annotation.ApplicationResponse
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -32,7 +34,7 @@ class OidcAuthServiceAdapter(
         ApiResponse(responseCode = "404", description = "해당 사용자 정보로 가입된 회원 정보 및 인증 정보가 존재하지 않음")
     ])
     @ApplicationResponse(status = HttpStatus.CREATED, message = "login with google success.")
-    override fun loginWithGoogle(request: OidcLoginRequest): LoginResponse {
+    override fun loginWithGoogle(@RequestBody @Valid request: OidcLoginRequest): LoginResponse {
         val result = oidcAuthUseCase.loginWithOidc(OidcMemberLoginCommand(
             platform = OidcPlatform.GOOGLE,
             idToken = request.idToken,

--- a/auth-api/src/main/kotlin/kr/respectme/auth/interfaces/adapter/RestAuthServiceAdapter.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/interfaces/adapter/RestAuthServiceAdapter.kt
@@ -37,6 +37,7 @@ class RestAuthServiceAdapter(private val authUseCase: AuthUseCase): AuthServiceP
     ])
     @PostMapping("/jwt")
     @ApplicationResponse(status=CREATED, message = "create token success.")
+    @Deprecated("이메일/패스워드를 통한 로그인은 사용되지 않습니다.")
     override fun login(@RequestBody @Valid request: LoginRequest): LoginResponse {
         val result = authUseCase.login(request)
         return LoginResponse.of(result)

--- a/auth-api/src/main/kotlin/kr/respectme/auth/interfaces/dto/OidcLoginRequest.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/interfaces/dto/OidcLoginRequest.kt
@@ -9,8 +9,9 @@ data class OidcLoginRequest(
     @field: NotEmpty
     @Schema(description = "OIDC 플랫폼 프로바이더가 제공한 ID Token, Firebase ID Token 사용 불가", required = true, example = "Google ID Token Or Apple ID Token")
     val idToken: String,
-    @Schema(description = "OIDC ID Token으로 로그인 시도 시, 404 에러가 발생하면 해당 필드를 채워 다시 요청을 보내면 회원가입 로직과 함께 수행됨")
-    val nickname: String?
+    @Schema(description = "OIDC ID Token으로 로그인 시도 시, 404 에러가 발생하면 해당 필드를 채워 다시 요청을 보내면 회원가입 로직과 함께 수행됨", required = false)
+    @Deprecated("더이상 사용되지 않습니다, 회원가입 로직은 자동으로 수행됩니다.")
+    val nickname: String?=null
 ) {
 
 }

--- a/auth-api/src/main/kotlin/kr/respectme/auth/interfaces/port/AuthServicePort.kt
+++ b/auth-api/src/main/kotlin/kr/respectme/auth/interfaces/port/AuthServicePort.kt
@@ -12,8 +12,6 @@ interface AuthServicePort {
 
     fun login(request: LoginRequest): LoginResponse
 
-//    fun verifyAccessToken(request: VerifyAccessTokenRequest): VerifyAccessTokenResponse
-
     fun retrieveAccessTokenVerificationRequirements(jwtToken: String): JwtAccessTokenVerifierRequiredInfo
 
     fun reissueAccessToken(request: RefreshAccessTokenRequest): LoginResponse

--- a/auth-api/src/test/kotlin/kr/respectme/auth/study/CreateServiceToken.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/study/CreateServiceToken.kt
@@ -4,8 +4,8 @@ import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import kr.respectme.auth.support.createJwtConfigs
 import org.junit.jupiter.api.Test
-import org.springframework.security.config.annotation.rsocket.RSocketSecurity.JwtSpec
 import java.time.Instant
+import java.util.UUID
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -27,7 +27,7 @@ class CreateServiceToken {
             .withIssuedAt(Instant.now())
             .withExpiresAt(Instant.now().plusMillis(jwtConfigs.accessTokenExpiry*1000L))
             .sign(accessTokenAlgorithm)
-        println("Auth Service Access token : ${token}")
+        println("Auth Service : ${token}")
         println("RESPECT_ME_SERVICE_ACCOUNT_TOKEN: ${Base64.Default.encode(token.encodeToByteArray())}")
     }
 
@@ -80,5 +80,62 @@ class CreateServiceToken {
             .sign(accessTokenAlgorithm)
         println("Message Service Access token : ${token}")
         println("RESPECT_ME_SERVICE_ACCOUNT_TOKEN: ${Base64.Default.encode(token.encodeToByteArray())}")
+    }
+
+    private fun createMemberAccessToken(member: TestMember) {
+        val token = JWT.create()
+            .withIssuer(jwtConfigs.issuer)
+            .withSubject(member.id.toString())
+            .withClaim("email", member.email)
+            .withClaim("nickname", member.email)
+            .withArrayClaim("roles", arrayOf(member.role))
+            .withClaim("isActivated", true)
+            .withIssuedAt(Instant.now())
+            .withExpiresAt(Instant.now().plusMillis(jwtConfigs.accessTokenExpiry*1000L))
+            .sign(accessTokenAlgorithm)
+        println("${member.email} Access token : ${token}")
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun `유저 별 Token 발급`() {
+        val members = listOf(
+        TestMember.of("01917f7a-3d9f-75aa-be6b-ef76d583653b", "admin@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 2),
+        TestMember.of("01917f7b-0355-7bd1-ae89-16f61bf7405c", "member-service@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01917f7b-28a5-7dce-9f54-5ef9349c6ef3", "auth-service@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01917f7a-aeeb-7d60-893b-e4c7c60ff9b9", "member1@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01917f7a-d55a-769e-9205-c328897c2fbf", "member2@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01918043-8f6f-7930-a283-f84ded99d409", "member3@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01918043-9105-755b-9940-ab9a24f0bb7d", "member4@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01918043-eb60-7300-9487-4fa0366b5f2a", "member5@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01918043-ed15-7ac9-98b9-c0b67ac717bc", "member6@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01918043-eed7-7705-99c2-c3903babdce0", "member7@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01918050-b1e6-7cd3-8ad4-476167dac987", "member8@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01918050-b415-7b50-b5e1-bde5b7873811", "member9@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3),
+        TestMember.of("01918050-b60f-713a-aa40-2690654ae405", "member10@respect-me.kr", "$2b$12\$W73CKCBO927PQ/LOzVlX2uKwxJQsbHRbZwt7Y1f6miKfuAOThQrzG", 3))
+        members.forEach { createMemberAccessToken(it) }
+    }
+
+    class TestMember(
+        val id : UUID,
+        val email: String,
+        val password: String,
+        val role: String
+    ) {
+        companion object {
+            fun of(
+                id: String,
+                email: String,
+                password: String,
+                role: Int
+            ): TestMember {
+                return TestMember(
+                    id = UUID.fromString(id),
+                    email = email,
+                    password = password,
+                    role = if(role == 2) "ROLE_ADMIN" else "ROLE_MEMBER"
+                )
+            }
+        }
     }
 }

--- a/auth-api/src/test/kotlin/kr/respectme/auth/support/EntitySupports.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/support/EntitySupports.kt
@@ -1,0 +1,55 @@
+package kr.respectme.auth.support
+
+import kr.respectme.auth.domain.MemberAuthInfo
+import kr.respectme.auth.domain.MemberId
+import kr.respectme.auth.domain.OidcAuth
+import kr.respectme.auth.domain.OidcPlatform
+import kr.respectme.auth.infrastructures.dto.Member
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import java.util.*
+import kotlin.random.Random
+
+
+fun createMemberAuthInfo(): MemberAuthInfo {
+    val password = BCryptPasswordEncoder().encode("test1234")
+
+    return MemberAuthInfo(
+        memberId = MemberId.of(UUID.randomUUID()),
+        email = "${UUID.randomUUID()}@respect-me.kr",
+        password = password,
+        oidcAuth = createOidcInfo(),
+    )
+}
+
+fun createMemberEntityFromMemberService(
+    id: UUID = UUID.randomUUID(),
+    email: String = "${id}@respect-me.kr",
+    nickname: String = "test",
+    role: String = "ROLE_USER",
+    isBlocked: Boolean = false,
+    blockReason: String = ""
+): Member {
+    return Member(
+        id = id,
+        email = email,
+        nickname = nickname,
+        role = role,
+        isBlocked = isBlocked,
+        blockReason = blockReason
+    )
+}
+
+private fun createOidcInfo(): OidcAuth {
+    val value = Random(1).nextInt() % 2 + 1;
+
+    return when(value) {
+        1 -> OidcAuth(
+            platform = OidcPlatform.GOOGLE,
+            userIdentifier = UUID.randomUUID().toString()
+        )
+        else -> OidcAuth(
+            platform = OidcPlatform.APPLE,
+            userIdentifier = UUID.randomUUID().toString()
+        )
+    }
+}

--- a/auth-api/src/test/kotlin/kr/respectme/auth/support/JwtSupports.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/support/JwtSupports.kt
@@ -2,8 +2,14 @@ package kr.respectme.auth.support
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import kr.respectme.auth.application.oidc.idToken.CommonOidcIdTokenPayload
 import kr.respectme.auth.configs.JwtConfigs
+import kr.respectme.auth.domain.MemberAuthInfo
+import kr.respectme.auth.domain.OidcPlatform
 import kr.respectme.auth.infrastructures.dto.Member
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPrivateKey
 import java.util.*
 
 fun createJwtConfigs(
@@ -26,7 +32,11 @@ fun createAccessToken(member: Member, configs: JwtConfigs, timestamp: Long = 360
     return JWT.create()
         .withIssuer(configs.issuer)
         .withClaim("id", member.id.toString())
-        .withClaim("role", member.role)
+        .withArrayClaim("roles", arrayOf(member.role))
+        .withClaim("email", member.email)
+        .withClaim("nickname", member.nickname)
+        .withClaim("isActivated", !member.isBlocked)
+        .withSubject(member.id.toString())
         .withExpiresAt(Date(System.currentTimeMillis() + timestamp))
         .sign(Algorithm.HMAC256(configs.accessTokenSecretKey))
 }
@@ -34,8 +44,101 @@ fun createAccessToken(member: Member, configs: JwtConfigs, timestamp: Long = 360
 fun createRefreshToken(member: Member, configs: JwtConfigs, timestamp: Long = 360000, permanent: Boolean = false): String {
     return JWT.create()
         .withIssuer(configs.issuer)
-        .withClaim("id", member.id.toString())
-        .withClaim("role", member.role)
+        .withSubject(member.id.toString())
         .withExpiresAt(Date(System.currentTimeMillis() + timestamp))
         .sign(Algorithm.HMAC256(configs.refreshTokenSecretKey))
+}
+
+fun createServiceAccountToken(configs: JwtConfigs): String {
+    return JWT.create()
+        .withIssuer(configs.issuer)
+        .withClaim("id", UUID.randomUUID().toString())
+        .withClaim("email", "service-account@respect-me.kr")
+        .withClaim("nickname", "service")
+        .withClaim("isActivated", true)
+        .withSubject(UUID.randomUUID().toString())
+        .withArrayClaim("roles", arrayOf("ROLE_SERVICE"))
+        .withExpiresAt(Date(System.currentTimeMillis() + 360000))
+        .sign(Algorithm.HMAC256(configs.accessTokenSecretKey))
+}
+
+fun createRSAKeyPair(): KeyPair {
+    val keyGen = KeyPairGenerator.getInstance("RSA")
+    keyGen.initialize(2048)
+    return keyGen.generateKeyPair()
+}
+
+fun createSampleAppleIdToken(
+    keyPair: KeyPair,
+    issuer: String = "https://appleid.apple.com",
+    audience: String = "sample-audience",
+    keyId: String = "sample-kid",
+    sub: String = "sample-sub",
+    email: String = "sample-email@respect-me.kr",
+    emailVerified: Boolean = true,
+    isPrivateEmail: Boolean = true,
+    nonceSupported: Boolean = true
+): String {
+    val algorithm = Algorithm.RSA256(null, keyPair.private as RSAPrivateKey)
+    return JWT.create()
+        .withIssuer(issuer)
+        .withKeyId(keyId)
+        .withSubject(sub)
+        .withAudience(audience)
+        .withClaim("email", email)
+        .withClaim("email_verified", emailVerified)
+        .withClaim("is_private_email", isPrivateEmail)
+        .withClaim("nonce_supported", nonceSupported)
+        .withIssuedAt(Date(System.currentTimeMillis()))
+        .withExpiresAt(Date(System.currentTimeMillis() + 360000))
+        .sign(algorithm)
+}
+
+fun createSampleGoogleIdToken(
+    keyPair: KeyPair,
+    keyId: String = "sample-kid",
+    issuer: String = "https://accounts.google.com",
+    audience: String = "sample-audience",
+    sub: String = "sample-sub",
+    email: String = "sample-email@respect-me.kr",
+    emailVerified: Boolean = true,
+    name: String = "sample-name",
+    picture: String = "https://sample.com/sample.jpg",
+    givenName: String = "sample-given-name",
+    familyName: String = "sample-family-name",
+    locale: String = "ko-KR",
+): String {
+    val algorithm = Algorithm.RSA256(null, keyPair.private as RSAPrivateKey)
+    return JWT.create()
+        .withIssuer(issuer)
+        .withKeyId(keyId)
+        .withSubject(sub)
+        .withAudience(audience)
+        .withClaim("email", email)
+        .withClaim("email_verified", emailVerified)
+        .withClaim("name", name)
+        .withClaim("picture", picture)
+        .withClaim("given_name", givenName)
+        .withClaim("family_name", familyName)
+        .withClaim("locale", locale)
+        .withIssuedAt(Date(System.currentTimeMillis()))
+        .withExpiresAt(Date(System.currentTimeMillis() + 360000))
+        .sign(algorithm)
+}
+
+fun createOidcCommonPayload(
+    idToken: String
+): CommonOidcIdTokenPayload {
+    val decodedToken = JWT.decode(idToken)
+
+    return CommonOidcIdTokenPayload(
+        iss = decodedToken.issuer,
+        sub = decodedToken.subject,
+        aud = decodedToken.audience,
+        exp = decodedToken.expiresAt.time,
+        iat = decodedToken.issuedAt.time,
+        email = decodedToken.getClaim("email").asString(),
+        name = decodedToken.getClaim("name").asString(),
+        profileImageUrl = ""
+    )
 }

--- a/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/jwt/JwtServiceTest.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/jwt/JwtServiceTest.kt
@@ -1,0 +1,100 @@
+package kr.respectme.auth.unit.application.jwt
+
+import com.auth0.jwt.exceptions.JWTVerificationException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kr.respectme.auth.application.jwt.JwtService
+import kr.respectme.auth.infrastructures.dto.Member
+import kr.respectme.auth.support.createJwtConfigs
+import kr.respectme.common.error.UnauthorizedException
+import java.util.UUID
+
+class JwtServiceTest : AnnotationSpec() {
+
+    private val jwtConfig = createJwtConfigs(accessTokenExpiry = 60000, refreshTokenExpiry = 60000)
+
+    private val jwtService = JwtService(jwtConfig)
+
+    private lateinit var member: Member;
+
+    private lateinit var expiredAccessToken: String
+
+    private lateinit var expiredRefreshToken: String
+
+    @BeforeEach
+    fun setUp() {
+        member = Member(
+            id = UUID.randomUUID(),
+            nickname = "nickname",
+            email = "nickname@respect-me.kr",
+            role = "ROLE_MEMBER",
+            isBlocked = false,
+            blockReason = ""
+        )
+
+        val tmpService = JwtService(createJwtConfigs(accessTokenExpiry = 1, refreshTokenExpiry = 1))
+        expiredAccessToken = tmpService.createAccessToken(member)
+        expiredRefreshToken = tmpService.createRefreshToken(member.id)
+    }
+
+    @Test
+    fun `멤버 객체가 주어지면 Access Token이 생성된다`() {
+        // given
+        val member = this.member
+
+        //When
+        val accessToken = jwtService.createAccessToken(member)
+        val decodedJwt = jwtService.verifyAccessToken(accessToken)
+        //Then
+        accessToken shouldNotBe null
+        decodedJwt.subject shouldBe member.id.toString()
+        decodedJwt.getClaim("email").asString() shouldBe member.email
+        decodedJwt.getClaim("nickname").asString() shouldBe member.nickname
+        decodedJwt.getClaim("roles").asList(String::class.java) shouldBe listOf(member.role)
+        decodedJwt.getClaim("isActivated").asBoolean() shouldBe !member.isBlocked
+    }
+
+    @Test
+    fun `멤버 객체가 주어지면 Refresh Token이 생성된다`() {
+        // given
+        val memberId = member.id
+
+        //When
+        val refreshToken = jwtService.createRefreshToken(memberId)
+        val decodedJwt = jwtService.verifyRefreshToken(refreshToken)
+        //Then
+        refreshToken shouldNotBe null
+        decodedJwt.subject shouldBe memberId.toString()
+    }
+
+    @Test
+    fun `만료된 Access Token을 검증하면 UnauthorizedException이 발생한다`() {
+        // given
+        val expiredAccessToken = this.expiredAccessToken
+
+        //When
+        val exception = shouldThrowAny {
+            jwtService.verifyAccessToken(expiredAccessToken)
+        }
+
+        //Then
+        exception::class.java shouldBe UnauthorizedException::class.java
+    }
+
+    @Test
+    fun `만료된 Refresh Token을 검증하면 UnauthorizedException이 발생한다`() {
+        // given
+        val expiredRefreshToken = this.expiredRefreshToken
+
+        //When
+        val exception = shouldThrowAny {
+            jwtService.verifyRefreshToken(expiredRefreshToken)
+        }
+
+        //Then
+        exception::class.java shouldBe UnauthorizedException::class.java
+    }
+}

--- a/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/oidc/AppleJwksProviderTest.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/oidc/AppleJwksProviderTest.kt
@@ -1,0 +1,33 @@
+package kr.respectme.auth.unit.application.oidc
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import kr.respectme.auth.application.oidc.AppleJwksProvider
+import kr.respectme.auth.application.oidc.JWKKey
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import org.springframework.web.reactive.function.client.WebClient
+
+class AppleJwksProviderTest: AnnotationSpec() {
+
+    private val webClient = WebClient.create()
+
+    private val objectMapper = Jackson2ObjectMapperBuilder.json().build<ObjectMapper>()
+
+    private val appleJwksProvider = AppleJwksProvider(webClient, objectMapper)
+
+    private val sampleJwkKey = JWKKey(
+        kty="RSA",
+        kid="dMlERBaFdK",
+        use="sig",
+        alg="RS256",
+        n="ryLWkB74N6SJNRVBjKF6xKMfP-QW3AAsJotv0LjVtf7m4NZNg_gTL78e7O8wmvngF8FuzBrvqf1mGW17Ct8BgNK6YXxnoGL0YLmlwXbmCZvTXki0VlEW1PDXeViWy7qXaCp2caF5v4OOdPsgroxNO_DgJRTuA_izJ4DFZYHCHXwojfdWJiDYG67j5PlD5pXKGx7zaqyryjovZTEII_Z1_bhFCRUZRjfJ3TVoK0fZj2z7iAZWjn33i-V3zExUhwzEyeuGph0118NfmOLCUEy_Jd4xvLf_X4laPpe9nq8UeORfs72yz2qH7cHDKL85W6oG08Gu05JWuAs5Ay49WxJrmw",
+        e="AQAB"
+    )
+
+    @Test
+    fun `createPublicKey Test`() {
+        val publicKey = appleJwksProvider.getPublicKey(sampleJwkKey.kid)
+        publicKey.algorithm shouldBe "RSA"
+    }
+}

--- a/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/oidc/GoogleJwksProviderTest.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/oidc/GoogleJwksProviderTest.kt
@@ -1,0 +1,34 @@
+package kr.respectme.auth.unit.application.oidc
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import kr.respectme.auth.application.oidc.GoogleJwksProvider
+import kr.respectme.auth.application.oidc.JWKKey
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import org.springframework.web.reactive.function.client.WebClient
+
+class GoogleJwksProviderTest: AnnotationSpec() {
+
+    private val webClient = WebClient.create()
+    private val objectMapper = Jackson2ObjectMapperBuilder.json().build<ObjectMapper>()
+
+    private val googleJwksProvider = GoogleJwksProvider(webClient, objectMapper)
+    private val sampleJwkKey = JWKKey(
+        kid = "31b8fccb2e52253b133138acf0e56632f09957ee",
+        kty = "RSA",
+        alg = "RS256",
+        e = "AQAB",
+        use = "sig",
+        n ="qL80q4yfbwG9vt_x1CBgv51oMOlOV1nEIWxcPrEJ_hd1Zf6Tv-gGNQUTzdRqhWUB7VZbIe7IGQ8XrqqZhJkSSRutWYgcB7CZAQPsz2uUzJfULIrqU5-3s1V6TsAvDd0XAhTrxsukBZhvSUcObns6oyr2tvCeYkdlbZ7HHgUjGLt2JduwfVfSDVOXm9iev36W0cDv2RS45H7c4rBaXnvhMQ6BOMA8xeSI05SCwYGpZp5prgQE_xyBPB_EHBOheDOgdtOEvceGg4zMSRni7a5S0ux5EmTOUVxMXOdOzlLmBHMNPYpAjjgYz4afhNuwAlp0BhEhSWwINOGh22U8iU1pIQ"
+    )
+
+    @Test
+    fun `createPublicKey Test`() {
+        val publicKey = googleJwksProvider.getPublicKey(sampleJwkKey.kid)
+        publicKey.algorithm shouldBe "RSA"
+    }
+
+}

--- a/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/oidc/IdTokenVerifierTest.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/oidc/IdTokenVerifierTest.kt
@@ -1,0 +1,58 @@
+package kr.respectme.auth.unit.application.oidc
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import kr.respectme.auth.application.oidc.AppleJwksProvider
+import kr.respectme.auth.application.oidc.GoogleJwksProvider
+import kr.respectme.auth.application.oidc.IdTokenVerifier
+import kr.respectme.auth.support.createRSAKeyPair
+import kr.respectme.auth.support.createSampleAppleIdToken
+import kr.respectme.auth.support.createSampleGoogleIdToken
+import java.security.interfaces.RSAPublicKey
+
+class IdTokenVerifierTest: AnnotationSpec() {
+
+    private val googleJwksProvider: GoogleJwksProvider = mockk()
+    private val appleJwksProvider: AppleJwksProvider = mockk()
+    private val idTokenVerifier = IdTokenVerifier(googleJwksProvider, appleJwksProvider)
+
+    @Test
+    fun `Apple Id Token을 검증한다`() {
+        // given
+        val keyPair = createRSAKeyPair()
+        val idToken = createSampleAppleIdToken(keyPair)
+        println(idToken)
+        every { appleJwksProvider.getPublicKey( any() ) } returns (keyPair.public as RSAPublicKey)
+
+        // when
+        val payload = idTokenVerifier.verifyToken(idToken)
+
+        // then
+        payload.iss shouldBe "https://appleid.apple.com"
+    }
+
+    @Test
+    fun `Google Id Token을 검증한다`() {
+        // given
+        val keyPair = createRSAKeyPair()
+        val idToken = createSampleGoogleIdToken(
+            keyPair = keyPair,
+        )
+
+        every { googleJwksProvider.getPublicKey( any() ) } returns (keyPair.public as RSAPublicKey)
+
+        // when
+        val payload = idTokenVerifier.verifyToken(idToken)
+
+        // then
+        payload.iss shouldBe "https://accounts.google.com"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+}

--- a/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/service/AuthServiceTest.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/service/AuthServiceTest.kt
@@ -1,0 +1,130 @@
+package kr.respectme.auth.unit.application.service
+
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import kr.respectme.auth.application.AuthService
+import kr.respectme.auth.application.dto.AuthenticationResult
+import kr.respectme.auth.application.dto.JwtAccessTokenVerifierRequiredInfo
+import kr.respectme.auth.application.jwt.JwtService
+import kr.respectme.auth.domain.MemberAuthInfoRepository
+import kr.respectme.auth.infrastructures.dto.LoginRequest
+import kr.respectme.auth.infrastructures.dto.Member
+import kr.respectme.auth.infrastructures.ports.MemberLoadPort
+import kr.respectme.auth.support.*
+import kr.respectme.common.error.NotFoundException
+import kr.respectme.common.error.UnauthorizedException
+import kr.respectme.common.response.ApiResult
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+
+class AuthServiceTest() : BehaviorSpec({
+
+    val jwtConfigs = createJwtConfigs(accessTokenExpiry = 600000, refreshTokenExpiry = 86400000L)
+    val jwtService = JwtService(jwtConfigs)
+    val memberLoadPort = mockk<MemberLoadPort>()
+    val authInfoRepository = mockk<MemberAuthInfoRepository>()
+    val memberAuthInfo = createMemberAuthInfo()
+    val passwordEncoder = BCryptPasswordEncoder()
+    val existMember = createMemberAuthInfo()
+    val authService = AuthService(jwtService, jwtConfigs, memberLoadPort, authInfoRepository, passwordEncoder)
+
+    Given("로그인 요청이 주어진다.") {
+        val request = LoginRequest(email = existMember.email, password = "test1234")
+        val invalidPasswordRequest = LoginRequest(email = existMember.email, password = "invalidPassword")
+
+        When("회원 정보가 존재하지 않으면") {
+            every { authInfoRepository.findByEmail(any()) } returns null
+            Then("로그인에 실패한다") {
+                val exception = shouldThrowAny {
+                    authService.login(request)
+                }
+
+                exception::class shouldBe NotFoundException::class
+            }
+        }
+
+        When("회원 정보가 존재하지만 비밀번호가 일치하지 않으면") {
+            every { authInfoRepository.findByEmail(any()) } returns memberAuthInfo
+
+            Then("로그인에 실패한다") {
+                val exception = shouldThrowAny {
+                    authService.login(invalidPasswordRequest)
+                }
+
+                exception::class shouldBe UnauthorizedException::class
+            }
+        }
+
+        When("회원 정보가 존재하고 비밀번호가 일치하면") {
+            val response = ApiResult<Member?>(data=createMemberEntityFromMemberService())
+            every { authInfoRepository.findByEmail(any()) } returns memberAuthInfo
+            every { memberLoadPort.loadMemberById(any()) } returns response
+            every { authInfoRepository.save(any()) } returns memberAuthInfo
+
+            Then("로그인에 성공한다") {
+                val result = authService.login(request)
+
+                result::class shouldBe AuthenticationResult::class
+                result.accessToken shouldNotBe null
+                result.refreshToken shouldNotBe null
+                result.memberId shouldNotBe existMember.memberId?.id
+            }
+        }
+    }
+
+    Given("엑세스 토큰 갱신 요청이 들어온다") {
+        val validRefreshToken = jwtService.createRefreshToken(memberAuthInfo.memberId!!.id)
+        val invalidAccessToken = jwtService.createAccessToken(Member(
+            id = memberAuthInfo.memberId!!.id,
+            email = memberAuthInfo.email,
+            role = "ROLE_ADMIN",
+            nickname = "test",
+            isBlocked = false,
+            blockReason = ""
+        ))
+
+        When("리프레시 토큰이 유효하지 않으면") {
+            val exception = shouldThrowAny {
+                authService.refreshAccessToken(invalidAccessToken)
+            }
+            Then("토큰 갱신에 실패한다") {
+                exception::class shouldBe UnauthorizedException::class
+            }
+        }
+
+        When("리프레시 토큰이 유효하면") {
+            val result = authService.refreshAccessToken(validRefreshToken)
+            Then("토큰 갱신에 성공한다") {
+                result::class shouldBe AuthenticationResult::class
+                result.accessToken shouldNotBe null
+                result.refreshToken shouldNotBe null
+                result.memberId shouldNotBe memberAuthInfo.memberId?.id
+            }
+        }
+    }
+
+    Given("JWT Token 검증을 위한 정보를 요청한다") {
+        val validServiceAccountToken = createServiceAccountToken(jwtConfigs)
+        val invalidToken = createAccessToken(createMemberEntityFromMemberService(), jwtConfigs)
+        When("요청자의 JWT Token의 파싱 결과 내부 서비스가 아니라면") {
+            val exception = shouldThrowAny {
+                authService.retrieveAccessTokenVerifierRequiredInfo(invalidToken)
+            }
+
+            Then("에러가 발생한다") {
+                exception::class shouldBe UnauthorizedException::class
+            }
+        }
+
+        When("내부 서비스라면") {
+            val result = authService.retrieveAccessTokenVerifierRequiredInfo("Bearer " +      validServiceAccountToken)
+
+            Then("토큰 검증 정보를 반환한다") {
+                result::class shouldBe JwtAccessTokenVerifierRequiredInfo::class
+            }
+        }
+    }
+})

--- a/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/service/DefaultOidcAuthServiceTest.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/unit/application/service/DefaultOidcAuthServiceTest.kt
@@ -1,0 +1,122 @@
+package kr.respectme.auth.unit.application.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import kr.respectme.auth.application.DefaultOidcAuthService
+import kr.respectme.auth.application.dto.OidcMemberLoginCommand
+import kr.respectme.auth.application.jwt.JwtService
+import kr.respectme.auth.application.oidc.IdTokenVerifier
+import kr.respectme.auth.application.useCase.AuthUseCase
+import kr.respectme.auth.common.AuthenticationErrorCode
+import kr.respectme.auth.domain.MemberAuthInfoRepository
+import kr.respectme.auth.domain.OidcPlatform
+import kr.respectme.auth.infrastructures.ports.MemberLoadPort
+import kr.respectme.auth.infrastructures.ports.MemberSavePort
+import kr.respectme.auth.support.*
+import kr.respectme.common.error.UnauthorizedException
+import kr.respectme.common.response.ApiResult
+
+class DefaultOidcAuthServiceTest: BehaviorSpec({
+
+    val jwtConfigs = createJwtConfigs(accessTokenExpiry = 600000, refreshTokenExpiry = 86400000L)
+    val jwtService = JwtService(jwtConfigs)
+    val memberAuthInfo = createMemberAuthInfo()
+    val memberLoadPort = mockk<MemberLoadPort>()
+    val memberSavePort = mockk<MemberSavePort>()
+    val authInfoRepository = mockk<MemberAuthInfoRepository>()
+    val authUseCase = mockk<AuthUseCase>()
+    val idTokenVerifier = mockk<IdTokenVerifier>()
+
+    val oidcAuthService = DefaultOidcAuthService(
+        memberSavePort=memberSavePort,
+        jwtService=jwtService,
+        memberLoadPort=memberLoadPort,
+        authInfoRepository=authInfoRepository,
+        authUseCase = authUseCase,
+        idTokenVerifier = idTokenVerifier
+    )
+
+    Given("유효한 OIDC Id Token이 주어진다") {
+        val keyPair = createRSAKeyPair()
+        val idToken = createSampleGoogleIdToken(
+            keyPair = keyPair,
+            sub = memberAuthInfo.memberId!!.id.toString(),
+            email = memberAuthInfo.email,
+        )
+
+        When("회원 정보가 존재하지 않으면") {
+            val member = createMemberEntityFromMemberService(
+                id = memberAuthInfo.memberId!!.id,
+                email = memberAuthInfo.email,
+            )
+
+            every { authInfoRepository.findByEmail(any()) } returns null
+            every { memberSavePort.registerMember(any()) } returns ApiResult(data = member)
+            every { authInfoRepository.save(any()) } returns memberAuthInfo
+            every { memberLoadPort.loadMemberById(member.id) } returns ApiResult(data = member)
+            every { idTokenVerifier.verifyToken(idToken) } returns createOidcCommonPayload(idToken)
+            every { authInfoRepository.findByOidcAuthPlatformAndOidcAuthUserIdentifier(any(), any()) } returns null
+
+            Then("회원 정보를 생성하고 토큰을 발급한다") {
+                val request = OidcMemberLoginCommand(
+                    platform = OidcPlatform.GOOGLE,
+                    idToken = idToken,
+                    nickname = "test",
+                )
+
+                val result = oidcAuthService.loginWithOidc(request)
+                result.accessToken shouldNotBe null
+                result.refreshToken shouldNotBe null
+            }
+        }
+
+        When("회원 정보가 존재하면") {
+            val member = createMemberEntityFromMemberService(
+                id = memberAuthInfo.memberId!!.id,
+                email = memberAuthInfo.email,
+            )
+
+            every { authInfoRepository.findByEmail(any()) } returns memberAuthInfo
+            every { memberLoadPort.loadMemberById(member.id) } returns ApiResult(data = member)
+            every { idTokenVerifier.verifyToken(idToken) } returns createOidcCommonPayload(idToken)
+            every { authInfoRepository.findByOidcAuthPlatformAndOidcAuthUserIdentifier(any(), any()) } returns memberAuthInfo
+
+            Then("토큰을 발급한다") {
+                val request = OidcMemberLoginCommand(
+                    platform = OidcPlatform.GOOGLE,
+                    idToken = idToken
+                )
+
+                val result = oidcAuthService.loginWithOidc(request)
+                result.accessToken shouldNotBe null
+                result.refreshToken shouldNotBe null
+            }
+        }
+
+        When("Id Token이 유효하지 않으면") {
+            every { idTokenVerifier.verifyToken(idToken) } throws UnauthorizedException(AuthenticationErrorCode.OIDC_ID_TOKEN_VERIFICATION_FAILED)
+
+            Then("예외를 발생시킨다") {
+                shouldThrow<UnauthorizedException> {
+                    oidcAuthService.loginWithOidc(OidcMemberLoginCommand(
+                        platform = OidcPlatform.GOOGLE,
+                        idToken = idToken
+                    ))
+                }
+            }
+        }
+    }
+
+    afterEach {
+        clearMocks(memberLoadPort, memberSavePort, authInfoRepository, authUseCase)
+    }
+
+    afterContainer {
+        clearAllMocks()
+    }
+})

--- a/auth-api/src/test/kotlin/kr/respectme/auth/unit/domain/MemberAuthInfoRepositoryTest.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/unit/domain/MemberAuthInfoRepositoryTest.kt
@@ -1,0 +1,110 @@
+package kr.respectme.auth.unit.domain
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import kr.respectme.auth.domain.MemberAuthInfo
+import kr.respectme.auth.domain.MemberAuthInfoRepository
+import kr.respectme.auth.domain.OidcPlatform
+import kr.respectme.auth.support.createMemberAuthInfo
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+
+@DataJpaTest
+class MemberAuthInfoRepositoryTest(
+    private val memberAuthInfoRepository: MemberAuthInfoRepository
+): AnnotationSpec() {
+
+    private val memberInfos: MutableList<MemberAuthInfo> = mutableListOf()
+
+    @BeforeEach
+    fun setUp() {
+        memberInfos.clear()
+        repeat(10) {
+            memberInfos.add(createMemberAuthInfo())
+        }
+        memberAuthInfoRepository.saveAll(memberInfos)
+    }
+
+    @Test
+    fun `findByEmail Success Test`() {
+        // Given
+        val email = memberInfos.get(0).email;
+
+        // When
+        val member = memberAuthInfoRepository.findByEmail(email)
+
+        //Then
+        member shouldBe memberInfos.get(0)
+    }
+
+    @Test
+    fun `findByEmail Fail Test`() {
+        // Given
+        val email = "unknown-email@respect-me.kr"
+
+        // When
+        val member = memberAuthInfoRepository.findByEmail(email)
+
+        //Then
+        member shouldBe null
+    }
+
+    @Test
+    fun `findByOidcAuthPlatformAndOidcAuthUserIdentifier Success Test`() {
+        // Given
+        val member = memberInfos.get(0)
+        val platform = member.oidcAuth.platform
+        val identifier = member.oidcAuth.userIdentifier
+
+        // When
+        val result = memberAuthInfoRepository.findByOidcAuthPlatformAndOidcAuthUserIdentifier(platform, identifier!!)
+
+        // Then
+        result shouldBe member
+    }
+
+    @Test
+    fun `findByOidcAuthPlatformAndOidcAuthUserIdentifier Fail Test`() {
+        // Given
+        // Given
+        val platform = OidcPlatform.APPLE
+        val identifier = "doesnt-exist-identifier"
+
+        // When
+        val result = memberAuthInfoRepository.findByOidcAuthPlatformAndOidcAuthUserIdentifier(platform, identifier!!)
+
+        // Then
+        result shouldBe null
+    }
+
+    @Test
+    fun `existsByOidcAuthPlatformAndOidcAuthUserIdentifier Success Test`() {
+        // Given
+        val member = memberInfos.get(0)
+        val platform = member.oidcAuth.platform
+        val identifier = member.oidcAuth.userIdentifier
+
+        // When
+        val result = memberAuthInfoRepository.existsByOidcAuthPlatformAndOidcAuthUserIdentifier(platform, identifier!!)
+
+        // Then
+        result shouldBe true
+    }
+
+    @Test
+    fun `existsByOidcAuthPlatformAndOidcAuthUserIdentifier Fail Test`() {
+        // Given
+        val platform = OidcPlatform.APPLE
+        val identifier = "doesnt-exist-identifier"
+
+        // When
+        val result = memberAuthInfoRepository.existsByOidcAuthPlatformAndOidcAuthUserIdentifier(platform, identifier!!)
+
+        // Then
+        result shouldBe false
+    }
+
+    @AfterEach
+    fun tearDown() {
+        memberAuthInfoRepository.deleteAll()
+    }
+}

--- a/auth-api/src/test/kotlin/kr/respectme/auth/unit/domain/MemberAuthInfoTest.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/unit/domain/MemberAuthInfoTest.kt
@@ -1,0 +1,78 @@
+package kr.respectme.auth.unit.domain
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import kr.respectme.auth.domain.MemberAuthInfo
+import kr.respectme.auth.domain.MemberId
+import kr.respectme.auth.domain.OidcAuth
+import java.time.Instant
+import java.util.*
+
+class MemberAuthInfoTest : AnnotationSpec() {
+
+    @Test
+    fun `MemberAuthInfo constructor test`() {
+        // Given
+        // 생성자 정보가 주어지고
+        val id = MemberId(UUID.randomUUID())
+        val email = "test-email"
+        val password = "test-password"
+        val oidcAuth = OidcAuth()
+        val lastLoginAt = Instant.now()
+
+        // When
+        // MemberAuthInfo를 생성하면
+        val member = MemberAuthInfo(id, email, password, oidcAuth, lastLoginAt)
+
+        // Then
+        // 객체가 정상적으로 생성된다.
+        member.memberId shouldBe id
+        member.email shouldBe email
+        member.password shouldBe password
+        member.oidcAuth shouldBe oidcAuth
+        member.lastLoginAt shouldBe lastLoginAt
+    }
+
+    @Test
+    fun `equals method test`() {
+        // Given
+        // 서로 다른 ID를 가진 MemberAuthInfo가 주어지고
+        val id1 = MemberId(UUID.randomUUID())
+        val id2 = MemberId(UUID.randomUUID())
+        val email = "test-email"
+        val password = "test-password"
+        val oidcAuth = OidcAuth()
+        val lastLoginAt = Instant.now()
+
+        val member1 = MemberAuthInfo(id1, email, password, oidcAuth, lastLoginAt)
+        val member2 = MemberAuthInfo(id2, email, password, oidcAuth, lastLoginAt)
+
+        // When
+        // 두 객체를 비교하면
+        val result = member1 == member2
+
+        // Then
+        // 다르다고 나온다.
+        result shouldBe false
+    }
+
+    @Test
+    fun `hashCode Method test`() {
+        // Given
+        // 서로 다른 ID를 가진 MemberAuthInfo가 주어지고
+        val id1 = MemberId(UUID.randomUUID())
+        val id2 = MemberId(UUID.randomUUID())
+        val email = "test-email"
+        val password = "test-password"
+        val oidcAuth = OidcAuth()
+        val lastLoginAt = Instant.now()
+
+        // When
+        // 두 객체의 hashCode를 비교하면
+        val result = MemberAuthInfo(id1, email, password, oidcAuth, lastLoginAt).hashCode() == MemberAuthInfo(id2, email, password, oidcAuth, lastLoginAt).hashCode()
+
+        // Then
+        // 다르다고 나온다.
+        result shouldBe false
+    }
+}

--- a/auth-api/src/test/kotlin/kr/respectme/auth/unit/domain/OidcPlatformConverterTest.kt
+++ b/auth-api/src/test/kotlin/kr/respectme/auth/unit/domain/OidcPlatformConverterTest.kt
@@ -1,0 +1,35 @@
+package kr.respectme.auth.unit.domain
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import kr.respectme.auth.domain.OidcPlatform
+import kr.respectme.auth.domain.OidcPlatformConverter
+
+class OidcPlatformConverterTest: AnnotationSpec() {
+
+    private val converter = OidcPlatformConverter()
+
+    @Test
+    fun `ConvertToEntity test`() {
+        // Given
+        val platform = OidcPlatform.GOOGLE
+
+        // When
+        val result = converter.convertToEntityAttribute(platform.value)
+
+        // Then
+        result shouldBe OidcPlatform.GOOGLE
+    }
+
+    @Test
+    fun `ConvertToDatabase test`() {
+        // Given
+        val platform = OidcPlatform.GOOGLE
+
+        // When
+        val result = converter.convertToDatabaseColumn(platform)
+
+        // Then
+        result shouldBe OidcPlatform.GOOGLE.value
+    }
+}


### PR DESCRIPTION
# 인증 서비스 테스트 추가

[Application]
JWTService 유닛 테스트 추가
IDTokenVerifier 유닛 테스트 추가
플랫폼 별 JwtsProvider 유닛테스트 추가 
AuthService 유닛 테스트 추가
DefaultOidcAuthService 유닛테스트 추가

[JPA 관련]
- MemberAuthInfoRepository 추가 인터페이스 테스트
- MemberAuthInfo 생성자 테스트 및 equals, hashCode 테스트
- OidcPlatformConverter 테스트