### PR TITLE
feat: Group API 그룹 잔여 알림 수 조회 API 엔드포인트 추가

### DIFF
--- a/group-api/src/main/kotlin/kr/respectme/group/adapter/in/interfaces/query/RestNotificationQueryAdapter.kt
+++ b/group-api/src/main/kotlin/kr/respectme/group/adapter/in/interfaces/query/RestNotificationQueryAdapter.kt
@@ -1,0 +1,34 @@
+package kr.respectme.group.adapter.`in`.interfaces.query
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.tags.Tags
+import kr.respectme.common.annotation.LoginMember
+import kr.respectme.group.application.dto.notification.NotificationCountDto
+import kr.respectme.group.application.query.useCase.NotificationQueryUseCase
+import kr.respectme.group.port.`in`.interfaces.NotificationQueryPort
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.*
+
+@RestController
+@RequestMapping("/api/v1/")
+@Tags(Tag(name = "Notification API", description = "그룹 알림 조회 API"))
+class RestNotificationQueryAdapter(
+    private val notificationQueryUsecase: NotificationQueryUseCase
+): NotificationQueryPort {
+
+    @Operation(summary = "오늘 그룹에서 추가 발행 가능한 알림 수 반환", description = "오늘 발송된 그룹의 잔여 알림 수를 반환한다. 시간은 UTC 기준이며, YYYY-MM-DD 00:00:00 ~ 23:59:59 까지의 발행된 알림 수를 반환한다.")
+    @ApiResponses(value = [
+        ApiResponse(responseCode = "200", description = "그룹의 잔여 알림 개수 조회 성공"),
+    ])
+    @GetMapping("/notification-groups/{groupId}/notification-left-count")
+    override fun getTodayNotificationCount(@LoginMember loginId: UUID, @PathVariable groupId: UUID)
+    : NotificationCountDto {
+        return notificationQueryUsecase.getTodayNotificationCount(groupId)
+    }
+}

--- a/group-api/src/main/kotlin/kr/respectme/group/adapter/out/persistence/JpaQueryNotificationAdapter.kt
+++ b/group-api/src/main/kotlin/kr/respectme/group/adapter/out/persistence/JpaQueryNotificationAdapter.kt
@@ -1,0 +1,56 @@
+package kr.respectme.group.adapter.out.persistence
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import kr.respectme.group.adapter.out.persistence.entity.GroupNotificationQueryModel
+import kr.respectme.group.adapter.out.persistence.entity.notifications.QJpaGroupNotification
+import kr.respectme.group.port.out.persistence.QueryNotificationPort
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.stereotype.Repository
+import java.time.Instant
+import java.util.*
+
+@Repository
+class JpaQueryNotificationAdapter(
+    private val qf: JPAQueryFactory
+): QueryNotificationPort {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun findNotificationById(notificationId: UUID): GroupNotificationQueryModel? {
+        return null
+    }
+
+    override fun findByNotificationsByGroupId(
+        groupId: UUID,
+        cursorId: UUID,
+        pageable: Pageable
+    ): Slice<GroupNotificationQueryModel> {
+
+        return SliceImpl(
+            emptyList(),
+            pageable,
+            false
+        )
+    }
+
+    override fun findTodayNotificationCount(groupId: UUID): Int {
+        val notification = QJpaGroupNotification.jpaGroupNotification
+        // 쿼리 일시를 기준으로 YYYY-MM-DD 00:00:00 ~ 23:59:59 사이의 데이터를 조회
+        val today = Instant.now()
+
+        return qf.select(notification.count())
+            .from(notification)
+            .where(notification.groupId.eq(groupId)
+                .and(notification.createdAt.between(
+                    today.truncatedTo(java.time.temporal.ChronoUnit.DAYS),
+                    today.plusSeconds(86399)
+                ))
+            )
+            .fetchOne()
+            ?.toInt()
+            ?: 0
+    }
+}

--- a/group-api/src/main/kotlin/kr/respectme/group/application/dto/notification/NotificationCountDto.kt
+++ b/group-api/src/main/kotlin/kr/respectme/group/application/dto/notification/NotificationCountDto.kt
@@ -1,0 +1,10 @@
+package kr.respectme.group.application.dto.notification
+
+import java.util.*
+
+data class NotificationCountDto(
+    val groupId: UUID,
+    val count: Int
+) {
+
+}

--- a/group-api/src/main/kotlin/kr/respectme/group/application/query/NotificationQueryService.kt
+++ b/group-api/src/main/kotlin/kr/respectme/group/application/query/NotificationQueryService.kt
@@ -1,5 +1,33 @@
 package kr.respectme.group.application.query
 
-class NotificationQueryService {
+import kr.respectme.group.application.dto.notification.NotificationCountDto
+import kr.respectme.group.application.dto.notification.NotificationQueryModelDto
+import kr.respectme.group.application.query.useCase.NotificationQueryUseCase
+import kr.respectme.group.port.out.persistence.QueryNotificationPort
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import java.util.*
 
+@Service
+class NotificationQueryService(
+    private val notificationRepository: QueryNotificationPort
+): NotificationQueryUseCase {
+
+    private final val GROUP_ALARM_LIMIT_PER_DAYS = 5
+
+    override fun getNotification(memberId: UUID, notificationId: UUID): NotificationQueryModelDto {
+        TODO("Not yet implemented")
+    }
+
+    override fun getNotifications(memberId: UUID, groupId: UUID, pageable: Pageable): List<NotificationQueryModelDto> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getTodayNotificationCount(groupId: UUID): NotificationCountDto {
+
+        return NotificationCountDto(
+            groupId = groupId,
+            count = GROUP_ALARM_LIMIT_PER_DAYS - notificationRepository.findTodayNotificationCount(groupId)
+        )
+    }
 }

--- a/group-api/src/main/kotlin/kr/respectme/group/application/query/useCase/NotificationQueryService.kt
+++ b/group-api/src/main/kotlin/kr/respectme/group/application/query/useCase/NotificationQueryService.kt
@@ -1,5 +1,0 @@
-package kr.respectme.group.application.query.useCase
-
-class NotificationQueryService
-{
-}

--- a/group-api/src/main/kotlin/kr/respectme/group/application/query/useCase/NotificationQueryUseCase.kt
+++ b/group-api/src/main/kotlin/kr/respectme/group/application/query/useCase/NotificationQueryUseCase.kt
@@ -1,0 +1,39 @@
+package kr.respectme.group.application.query.useCase
+
+import kr.respectme.group.application.dto.notification.NotificationCountDto
+import kr.respectme.group.application.dto.notification.NotificationQueryModelDto
+import org.springframework.data.domain.Pageable
+import java.util.UUID
+
+/**
+ * NotificationQueryUseCase Inteface
+ * Define below methods
+ * - getNotification - get a notification with detail information
+ * - getNotifications - get a list of notifications with summarized content.
+ * - getTodayNotificationCount - get a count of notifications that are created today based on UTC.
+ */
+interface NotificationQueryUseCase {
+
+    /**
+     * get a notification with detail information
+     * @param notificationId - notification id
+     * @return NotificationDetail
+     */
+    fun getNotification(memberId: UUID, notificationId: UUID): NotificationQueryModelDto
+
+    /**
+     * get a list of notifications with summarized content.
+     * @param groupId - group id
+     * @param page - page number
+     * @param size - page size
+     * @return List<NotificationSummary>
+     */
+    fun getNotifications(memberId: UUID, groupId: UUID, pageable: Pageable): List<NotificationQueryModelDto>
+
+    /**
+     * get a count of notifications that are created today based on UTC.
+     * @param groupId - group id
+     * @return Int
+     */
+    fun getTodayNotificationCount(groupId: UUID): NotificationCountDto
+}

--- a/group-api/src/main/kotlin/kr/respectme/group/port/in/interfaces/NotificationQueryPort.kt
+++ b/group-api/src/main/kotlin/kr/respectme/group/port/in/interfaces/NotificationQueryPort.kt
@@ -1,0 +1,9 @@
+package kr.respectme.group.port.`in`.interfaces
+
+import kr.respectme.group.application.dto.notification.NotificationCountDto
+import java.util.*
+
+interface NotificationQueryPort {
+
+    fun getTodayNotificationCount(loginId: UUID, groupId: UUID): NotificationCountDto
+}

--- a/group-api/src/main/kotlin/kr/respectme/group/port/out/persistence/QueryNotificationPort.kt
+++ b/group-api/src/main/kotlin/kr/respectme/group/port/out/persistence/QueryNotificationPort.kt
@@ -1,0 +1,16 @@
+package kr.respectme.group.port.out.persistence
+
+import kr.respectme.group.adapter.out.persistence.entity.GroupNotificationQueryModel
+import kr.respectme.group.application.dto.notification.NotificationQueryModelDto
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import java.util.*
+
+interface QueryNotificationPort {
+
+    fun findNotificationById(notificationId: UUID): GroupNotificationQueryModel?
+
+    fun findByNotificationsByGroupId(groupId: UUID, cursorId:UUID, pageable: Pageable): Slice<GroupNotificationQueryModel>
+
+    fun findTodayNotificationCount(groupId: UUID): Int
+}

--- a/group-api/src/test/kotlin/kr/respectme/group/support/config/TestConfig.kt
+++ b/group-api/src/test/kotlin/kr/respectme/group/support/config/TestConfig.kt
@@ -1,0 +1,14 @@
+package kr.respectme.group.support.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class TestConfig {
+    @Bean
+    fun jpaQueryFactory(entityManager: EntityManager): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/group-api/src/test/kotlin/kr/respectme/group/unit/adapter/out/JpaQueryNotificationAdapterTest.kt
+++ b/group-api/src/test/kotlin/kr/respectme/group/unit/adapter/out/JpaQueryNotificationAdapterTest.kt
@@ -1,0 +1,99 @@
+package kr.respectme.group.unit.adapter.out
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import io.kotest.core.extensions.Extension
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import kr.respectme.group.adapter.out.persistence.JpaQueryNotificationAdapter
+import kr.respectme.group.adapter.out.persistence.entity.JpaGroupMember
+import kr.respectme.group.adapter.out.persistence.entity.JpaNotificationGroup
+import kr.respectme.group.adapter.out.persistence.entity.notifications.JpaGroupNotification
+import kr.respectme.group.adapter.out.persistence.entity.notifications.JpaImmediateNotification
+import kr.respectme.group.adapter.out.persistence.repository.JpaGroupMemberRepository
+import kr.respectme.group.adapter.out.persistence.repository.JpaGroupNotificationRepository
+import kr.respectme.group.adapter.out.persistence.repository.JpaGroupRepository
+import kr.respectme.group.domain.GroupMemberRole
+import kr.respectme.group.domain.notifications.NotificationStatus
+import kr.respectme.group.port.out.persistence.QueryNotificationPort
+import kr.respectme.group.support.config.TestConfig
+import kr.respectme.group.support.createJpaGroup
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import java.util.UUID
+
+@DataJpaTest
+@Import(TestConfig::class)
+class JpaQueryNotificationAdapterTest(
+    private val jpaGroupRepository: JpaGroupRepository,
+    private val jpaMemberRepository: JpaGroupMemberRepository,
+    private val jpaNotificationRepository: JpaGroupNotificationRepository,
+    private val qf: JPAQueryFactory,
+) : AnnotationSpec() {
+
+    private lateinit var members: List<JpaGroupMember>
+    private lateinit var groups: List<JpaNotificationGroup>
+    private lateinit var notifications: List<JpaGroupNotification>
+    private val jpaQueryNotificationAdapter = JpaQueryNotificationAdapter(qf)
+
+    override fun extensions(): List<Extension> {
+        return listOf(SpringExtension)
+    }
+
+    @BeforeEach
+    fun setUp() {
+        groups = createJpaGroup(1)
+        members = groups.map{ group ->
+            JpaGroupMember(
+                id = UUID.randomUUID(),
+                groupId = group.identifier,
+                memberId = UUID.randomUUID(),
+                nickname = "owner",
+                memberRole = GroupMemberRole.OWNER,
+            )
+        }
+        notifications = listOf(
+            JpaImmediateNotification(
+                id = UUID.randomUUID(),
+                groupId = groups[0].identifier,
+                memberId = members[0].memberId,
+                content = "content",
+                status = NotificationStatus.PENDING,
+            ),
+            JpaImmediateNotification(
+                id = UUID.randomUUID(),
+                groupId = groups[0].identifier,
+                memberId = members[0].memberId,
+                content = "content",
+                status = NotificationStatus.PENDING,
+            ),
+            JpaImmediateNotification(
+                id = UUID.randomUUID(),
+                groupId = groups[0].identifier,
+                memberId = members[0].memberId,
+                content = "content",
+                status = NotificationStatus.PENDING,
+            )
+        )
+
+        jpaGroupRepository.save(groups[0])
+        members.forEach { it -> jpaMemberRepository.save(it) }
+        notifications.forEach { it -> jpaNotificationRepository.save(it) }
+    }
+
+    @Test()
+    fun `그룹에 발행된 오늘 메시지 수를 조회한다`() {
+        val result = jpaQueryNotificationAdapter.findTodayNotificationCount(groups[0].identifier)
+        result shouldBe 3
+    }
+
+    @AfterEach
+    fun tearDown() {
+        jpaNotificationRepository.deleteAll()
+        jpaMemberRepository.deleteAll()
+        jpaGroupRepository.deleteByGroupId(groups[0].identifier)
+    }
+}

--- a/group-api/src/test/kotlin/kr/respectme/group/unit/application/NotificationServiceTest.kt
+++ b/group-api/src/test/kotlin/kr/respectme/group/unit/application/NotificationServiceTest.kt
@@ -1,4 +1,28 @@
 package kr.respectme.group.unit.application
 
-class NotificationServiceTest {
-}
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kr.respectme.group.application.query.NotificationQueryService
+import kr.respectme.group.port.out.persistence.QueryNotificationPort
+import java.util.*
+
+internal class NotificationServiceTest: BehaviorSpec({
+
+    val notificationQueryPort = mockk<QueryNotificationPort>()
+    val notificationService = NotificationQueryService(notificationQueryPort)
+
+    Given("그룹의 아이디가 주어진다") {
+        val groupId = UUID.randomUUID();
+
+        When("그룹에 오늘 발행된 메시지를 조회하면") {
+            every { notificationQueryPort.findTodayNotificationCount(groupId) } returns 5
+
+            Then("그룹에 오늘 발행된 메시지의 개수를 반환한다") {
+                val result = notificationService.getTodayNotificationCount(groupId)
+                result.count shouldBe 5
+            }
+        }
+    }
+})


### PR DESCRIPTION
# API 추가 사항

Group API 잔여 Endpoint 추가

요청
```http.request
GET /api/v1/notification-groups/{group-id}/notification-left-count HTTP/1.1
```

응답
```json
{
    "groupId": "abcd-efgh-hijk-lmno", // 그룹 아이디
    "count": 3 // 오늘 잔여 알림 갯수
}
```
